### PR TITLE
Correcting title and standardising DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -1,5 +1,5 @@
 {
-    "title": "OpenPain thermal",
+    "title": "OpenPain cbp_resting",
     "description": "Data added from ftp://openpain.org/cbp_resting, see http://openpain.org for more information.",
     
     "creators": [

--- a/DATS.json
+++ b/DATS.json
@@ -16,6 +16,20 @@
             "value": "fMRI"
         }
     ],
+    "distributions": [
+	        {
+			"formats": [
+				"NIfTI"
+            		],
+			"size" : 3.96,
+		        "unit" : {
+            			"value": "GB"
+		        },
+			"access": {
+				"landingPage": "https://www.openpain.org/"
+			}
+		}
+	],
     "version": "1.0",
     "privacy": "Open Access",
     "isAbout": [
@@ -30,7 +44,32 @@
             "values": [
                 {
                     "value": "136"
-                }
+                },
+
+	{
+			"category": "contact",
+			"values": [
+				{
+					"value": "A. Vania Apkarian, Director Center for Translational Pain Research, Northwestern University, Feinberg School of Medicine, a-apkarian@northwestern.edu"
+				}
+			]
+		},
+		{
+			"category": "files",
+			"values": [
+				{
+					"value": "418"
+				}
+			]
+		},
+		{
+			"category": "logo",
+			"values": [
+				{
+					"value": "http://openpain.org/images/OP_Pic1.jpg"
+				}
+			]
+		}
             ]
         }
     ]


### PR DESCRIPTION
This replaces the previous closed PR #1.  In addition to adding the standardised fields under distribution and extraProperties as documented in https://github.com/CONP-PCNO/conp-dataset/pull/125, the title field was changed from "openpain-thermal" to reflect the name of the repository.